### PR TITLE
webkit2gtk improvements

### DIFF
--- a/org.gnome.FontManager.yaml
+++ b/org.gnome.FontManager.yaml
@@ -32,6 +32,33 @@ modules:
 
   # Borrowed from Poedit
   # https://github.com/flathub/net.poedit.Poedit
+  - name: unifdef
+    no-autogen: true
+    make-install-args:
+      - prefix=${FLATPAK_DEST}
+
+    sources:
+      - type: archive
+        url: https://dotat.at/prog/unifdef/unifdef-2.12.tar.xz
+        sha256: 43ce0f02ecdcdc723b2475575563ddb192e988c886d368260bc0a63aee3ac400
+    cleanup:
+      - '*'
+
+  - name: libjxl # Remove when runtime is updated to 45
+    buildsystem: cmake
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_TESTING=OFF
+    sources:
+      - type: git
+        url: https://github.com/libjxl/libjxl.git
+        tag: v0.8.2
+        commit: 954b460768c08a147abf47689ad69b0e7beff65e
+        disable-shallow-clone: true
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$
+
   - name: webkit2gtk-4.0
     buildsystem: cmake-ninja
     config-opts:
@@ -44,8 +71,8 @@ modules:
       - -DUSE_SOUP2=ON
     sources:
       - type: archive
-        url: https://webkitgtk.org/releases/webkitgtk-2.38.6.tar.xz
-        sha256: 1c614c9589389db1a79ea9ba4293bbe8ac3ab0a2234cac700935fae0724ad48b
+        url: https://webkitgtk.org/releases/webkitgtk-2.42.0.tar.xz
+        sha256: 828f95935861fae583fb8f2ae58cf64c63c178ae2b7c2d6f73070813ad64ed1b
         x-checker-data:
           type: html
           url: https://webkitgtk.org/releases/

--- a/org.gnome.FontManager.yaml
+++ b/org.gnome.FontManager.yaml
@@ -34,7 +34,7 @@ modules:
   # https://github.com/flathub/net.poedit.Poedit
   - name: webkit2gtk-4.0
     buildsystem: cmake-ninja
-    config-opts: 
+    config-opts:
       - -DPORT=GTK
       - -DCMAKE_BUILD_TYPE=Release
       - -DENABLE_DOCUMENTATION=OFF
@@ -46,6 +46,11 @@ modules:
       - type: archive
         url: https://webkitgtk.org/releases/webkitgtk-2.38.6.tar.xz
         sha256: 1c614c9589389db1a79ea9ba4293bbe8ac3ab0a2234cac700935fae0724ad48b
+        x-checker-data:
+          type: html
+          url: https://webkitgtk.org/releases/
+          version-pattern: LATEST-STABLE-(\d[\.\d]+\d)
+          url-template: https://webkitgtk.org/releases/webkitgtk-$version.tar.xz
 
   - name: fontmanager
     buildsystem: meson


### PR DESCRIPTION
I don't know if this needs libjpegxl, I added it because it is turned on by default but I don't think it matters much as 45 will be out next week and it'll be included by default in the runtime

If it doesn't need this, for the short window there is a compile arg to turn it off.


Let me know if it os preferable to manage the version by hand instead of x-checker. Maintaining a working copy can be bit if a work.